### PR TITLE
💄 1:1 문의하기 페이지 전체 width 및 문의 글쓰기 영역 width 설정

### DIFF
--- a/src/pages/question/CreateQuestion.jsx
+++ b/src/pages/question/CreateQuestion.jsx
@@ -28,7 +28,7 @@ CreateQuestion.propTypes = {
 
 const StyledCreateQuestion = styled.div`
   box-sizing: border-box;
-  width: 100%;
+  width: 917px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/question/Question.jsx
+++ b/src/pages/question/Question.jsx
@@ -7,21 +7,29 @@ import { Outlet } from 'react-router-dom';
 
 export default function Question() {
   return (
-    <StyledWrapper>
+    <StyledQuestion>
       <ProfileCalendar />
-      <SideNav />
-      <div>
-        <Title />
-        <Outlet />
-      </div>
-    </StyledWrapper>
+      <StyledWrapper>
+        <SideNav />
+        <div>
+          <Title />
+          <Outlet />
+        </div>
+      </StyledWrapper>
+    </StyledQuestion>
   );
 }
 
-const StyledWrapper = styled.div`
-  display: grid;
-  grid-template-columns: 150px auto;
-  & > *:first-child {
-    grid-column: 1 / span 2;
+const StyledQuestion = styled.div`
+  display: flex;
+  flex-direction: column;
+  & > * {
+    width: 1084px;
   }
+  align-items: center;
+`;
+
+const StyledWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;

--- a/src/pages/question/SearchQuestion.jsx
+++ b/src/pages/question/SearchQuestion.jsx
@@ -10,7 +10,7 @@ export default function SearchQuestion() {
   const [startDate, setStartDate] = useState(DATE_TEMPLATE(new Date()));
   const [endDate, setEndDate] = useState(DATE_TEMPLATE(new Date()));
   return (
-    <div>
+    <StyledSearchQuestion>
       <DateSelector
         startDate={startDate}
         setStartDate={setStartDate}
@@ -27,9 +27,13 @@ export default function SearchQuestion() {
         <StyledLink to="/question/create">1:1 문의하기</StyledLink>
       </StyledSection>
       <QuestionTable />
-    </div>
+    </StyledSearchQuestion>
   );
 }
+
+const StyledSearchQuestion = styled.div`
+  width: 917px;
+`;
 
 const StyledSection = styled.div`
   margin-top: 54px;


### PR DESCRIPTION
## Related Issues

- close #38 

## What did you do?

<!--무엇을 하셨나요?-->

- [x] 1:1 문의하기 페이지 전체 width 설정
- [x] 문의 글쓰기 영역 width 설정

## 고민한 점

[Question 컴포넌트]
- Question 컴포넌트에서 전체 width를 설정하는데 display가 grid인 상태에서 이것저것 해봤지만 잘 안돼서 flex로 바꿈
- 그래서 왼쪽 네비바와 중첩라우터 영역을 StyledWrapper 컴포넌트로 감쌈
- 그리고 각각의 요소(ProfileCalendar, StyledWrapper)를 1084px로 width 설정해줌
- StyledWrapper도 flex로 설정해서 space-between으로 각각의 위치를 잡음

[CreateQuestion 컴포넌트]
- StyledWrapper가 flex여서 width가 제대로 안잡혀서 아예 917px로 설정해줌
- 같은 이유로 SearchQuestion도 딱 들어맞는 상태는 아닌데 이 방식이 괜찮은지 일단 코드 리뷰 한 번 받는게 좋을 것 같아서 손 안댐!

## 질문
- 전체 틀 flex로 바꿔서 각각에 1084px로 width 설정한 방식 괜찮은지
- StyledWrapper만 이전이랑 똑같은 grid 설정으로 할까?? 그럼 보기에 큰 차이는 없지만 917px여야 하는 width가 934px긴 해!
- 전체 width 피그마에서 계산해보니 1084px 나왔는데 혹시 아니면 말해줘..??
- 이외에도 어떤지 의견 있으면 주시오 ~ ~
