### PR TITLE
반응형용 훅 만들고 헤더에 적용 

### DIFF
--- a/src/components/common/Base.layout.jsx
+++ b/src/components/common/Base.layout.jsx
@@ -1,0 +1,27 @@
+import { PropTypes } from 'prop-types';
+import React from 'react';
+import useResponsive from '../../hooks/useResponsive';
+
+export default function BaseLayout({
+  children,
+  BigScreen,
+  TabletOrDesktop,
+  MobileOrTablet,
+  Mobile,
+}) {
+  const { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile } = useResponsive();
+
+  if (isBigScreen) return <BigScreen>{children}</BigScreen>;
+  if (isTabletOrDesktop) return <TabletOrDesktop>{children}</TabletOrDesktop>;
+  if (isMobileOrTablet) return <MobileOrTablet>{children}</MobileOrTablet>;
+  if (isMobile) return <Mobile>{children}</Mobile>;
+  return <>{children}</>;
+}
+
+BaseLayout.propTypes = {
+  children: PropTypes.element,
+  BigScreen: PropTypes.element,
+  TabletOrDesktop: PropTypes.element,
+  MobileOrTablet: PropTypes.element,
+  Mobile: PropTypes.element,
+};

--- a/src/components/common/Base.layout.jsx
+++ b/src/components/common/Base.layout.jsx
@@ -1,5 +1,5 @@
-import { PropTypes } from 'prop-types';
 import React from 'react';
+import { PropTypes } from 'prop-types';
 import useResponsive from '../../hooks/useResponsive';
 
 export default function BaseLayout({

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -2,35 +2,44 @@ import React from 'react';
 import styled from 'styled-components';
 import { IcHeart, IcLogout, IcSearch, IcUser, Logo } from './Icon';
 import { colors } from '../../styles/color';
+import HeaderLayout from './Header.layout';
 
 export default function Header() {
   return (
     <StyledWrapper>
-      <StyledNotice>
-        <div>[Notice] 쇼룸 고객을 위한 1:1 맞춤 고객상담 서비스를 소개합니다.</div>
-        <div>
-          <StyledCounselButton>상담신청하러 가기</StyledCounselButton>
-        </div>
-      </StyledNotice>
-      <StyledBanner>
-        <Logo />
-        <StyledMiddleMenu>
-          <div>SPACE</div>
-          <div>PAPER</div>
-          <div>CONTENTS</div>
-          <div>ABOUT US</div>
-        </StyledMiddleMenu>
-        <StyledRightMenu>
-          <StyledSearchBar>
-            <input type="text" placeholder="상품검색" />
-            <IcSearch width="40" height="40" />
-          </StyledSearchBar>
-          <IcHeart width="40" height="40" />
-          <IcUser width="40" height="40" />
-          <IcLogout width="40" height="40" />
-          <div>ENGLISH</div>
-        </StyledRightMenu>
-      </StyledBanner>
+      <HeaderLayout>
+        <StyledNotice>
+          <div>
+            <span className="hide-less-than-mobile">[Notice] 쇼룸 고객을 위한 </span>
+            <span>1:1 맞춤 고객상담 서비스</span>
+            <span className="hide-less-than-mobile">를 소개합니다.</span>
+          </div>
+          <div>
+            <StyledCounselButton>상담신청하러 가기</StyledCounselButton>
+          </div>
+        </StyledNotice>
+      </HeaderLayout>
+      <HeaderLayout>
+        <StyledBanner>
+          <Logo />
+          <StyledMiddleMenu>
+            <div>SPACE</div>
+            <div>PAPER</div>
+            <div>CONTENTS</div>
+            <div>ABOUT US</div>
+          </StyledMiddleMenu>
+          <StyledRightMenu>
+            <StyledSearchBar className="reset-less-than-tablet">
+              <input type="text" placeholder="상품검색" className="hide-less-than-tablet" />
+              <IcSearch width="40" height="40" />
+            </StyledSearchBar>
+            <IcHeart width="40" height="40" />
+            <IcUser width="40" height="40" />
+            <IcLogout width="40" height="40" />
+            <div className="hide-less-than-mobile">ENGLISH</div>
+          </StyledRightMenu>
+        </StyledBanner>
+      </HeaderLayout>
     </StyledWrapper>
   );
 }
@@ -41,6 +50,9 @@ const StyledWrapper = styled.div`
   width: 100%;
   z-index: 999;
   margin-bottom: 46px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const StyledNotice = styled.div`

--- a/src/components/common/Header.layout.jsx
+++ b/src/components/common/Header.layout.jsx
@@ -1,7 +1,7 @@
-import { checkPropTypes } from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import useResponsive from '../../hooks/useResponsive';
+import { layoutPropTypes } from '../../utils/layoutPropTypes';
 
 export default function HeaderLayout({ children }) {
   const { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile } = useResponsive();
@@ -14,9 +14,7 @@ export default function HeaderLayout({ children }) {
   return <div>{children}</div>;
 }
 
-HeaderLayout.propTypes = {
-  children: checkPropTypes.any,
-};
+HeaderLayout.propTypes = layoutPropTypes;
 
 const StyledWrapper = styled.div`
   width: 100%;

--- a/src/components/common/Header.layout.jsx
+++ b/src/components/common/Header.layout.jsx
@@ -1,0 +1,76 @@
+import { checkPropTypes } from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import useResponsive from '../../hooks/useResponsive';
+
+export default function HeaderLayout({ children }) {
+  const { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile } = useResponsive();
+  if (isBigScreen) return <StyledDesktopWrapper>{children}</StyledDesktopWrapper>;
+  if (isTabletOrDesktop)
+    return <StyledTabletToDesktopWrapper>{children}</StyledTabletToDesktopWrapper>;
+  if (isMobileOrTablet)
+    return <StyledMobileToTabletWrapper>{children}</StyledMobileToTabletWrapper>;
+  if (isMobile) return <StyledMobileWrapper>{children}</StyledMobileWrapper>;
+  return <div>{children}</div>;
+}
+
+HeaderLayout.propTypes = {
+  children: checkPropTypes.any,
+};
+
+const StyledWrapper = styled.div`
+  width: 100%;
+  overflow: hidden;
+  & > div {
+    box-sizing: border-box;
+  }
+`;
+
+const StyledDesktopWrapper = styled(StyledWrapper)`
+  & > div {
+    padding-left: max(calc(50% - 540px), 20px);
+    padding-right: max(calc(50% - 540px), 20px);
+  }
+`;
+
+const StyledTabletToDesktopWrapper = styled(StyledDesktopWrapper)`
+  &:nth-child(2) {
+    & > div {
+      grid-template-columns: 1fr 3fr auto;
+      gap: 11px;
+    }
+  }
+  & .hide-less-than-tablet {
+    display: none;
+  }
+  & .reset-less-than-tablet {
+    all: unset;
+  }
+`;
+
+const StyledMobileToTabletWrapper = styled(StyledTabletToDesktopWrapper)`
+  &:nth-child(2) {
+    & > div {
+      display: flex;
+      justify-content: space-around;
+      width: 100%;
+      padding-bottom: 70px;
+      & > div {
+        gap: 13px;
+      }
+      & > div:nth-child(2) {
+        position: absolute;
+        top: 160px;
+        left: 20px;
+      }
+      & > div:nth-child(3) {
+        justify-content: flex-end;
+      }
+    }
+  }
+  & .hide-less-than-mobile {
+    display: none;
+  }
+`;
+
+const StyledMobileWrapper = styled(StyledMobileToTabletWrapper)``;

--- a/src/components/common/Header.layout.jsx
+++ b/src/components/common/Header.layout.jsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import styled from 'styled-components';
-import useResponsive from '../../hooks/useResponsive';
 import { layoutPropTypes } from '../../utils/layoutPropTypes';
+import BaseLayout from './Base.layout';
 
 export default function HeaderLayout({ children }) {
-  const { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile } = useResponsive();
-  if (isBigScreen) return <StyledDesktopWrapper>{children}</StyledDesktopWrapper>;
-  if (isTabletOrDesktop)
-    return <StyledTabletToDesktopWrapper>{children}</StyledTabletToDesktopWrapper>;
-  if (isMobileOrTablet)
-    return <StyledMobileToTabletWrapper>{children}</StyledMobileToTabletWrapper>;
-  if (isMobile) return <StyledMobileWrapper>{children}</StyledMobileWrapper>;
-  return <div>{children}</div>;
+  return (
+    <BaseLayout
+      BigScreen={StyledDesktopWrapper}
+      TabletOrDesktop={StyledTabletToDesktopWrapper}
+      MobileOrTablet={StyledMobileToTabletWrapper}
+      Mobile={StyledMobileWrapper}
+    >
+      {children}
+    </BaseLayout>
+  );
 }
 
 HeaderLayout.propTypes = layoutPropTypes;

--- a/src/hooks/useResponsive.js
+++ b/src/hooks/useResponsive.js
@@ -1,0 +1,10 @@
+import { useMediaQuery } from 'react-responsive';
+
+export default function useResponsive() {
+  const isBigScreen = useMediaQuery({ minWidth: 1920 });
+  const isTabletOrDesktop = useMediaQuery({ minWidth: 768, maxWidth: 1920 });
+  const isMobileOrTablet = useMediaQuery({ minWidth: 360, maxWidth: 768 });
+  const isMobile = useMediaQuery({ maxWidth: 360 });
+
+  return { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile };
+}

--- a/src/utils/layoutPropTypes.js
+++ b/src/utils/layoutPropTypes.js
@@ -1,5 +1,5 @@
-import { checkPropTypes } from 'prop-types';
+import { PropTypes } from 'prop-types';
 
 export const layoutPropTypes = {
-  children: checkPropTypes.any,
+  children: PropTypes.element,
 };

--- a/src/utils/layoutPropTypes.js
+++ b/src/utils/layoutPropTypes.js
@@ -1,0 +1,5 @@
+import { checkPropTypes } from 'prop-types';
+
+export const layoutPropTypes = {
+  children: checkPropTypes.any,
+};


### PR DESCRIPTION
## Related Issues

<!--#을 눌러 이슈와 연결해주세요-->
- close #41

## What did you do?

<!--무엇을 하셨나요?-->

- [x] 훅 만들기
이미 데스크탑 짱큰버전으로 모두 구현한 상황에서 어떻게 적용하는게 제일 적은 변화를 일으킬지 고민하다가
정말 범용성 좋게 짰습니다
(범용성이 좋다 ==> 딱! 제공해주는 기능이 얼마 없다..)

```jsx
import { useMediaQuery } from 'react-responsive';

export default function useResponsive() {
  const isBigScreen = useMediaQuery({ minWidth: 1920 });
  const isTabletOrDesktop = useMediaQuery({ minWidth: 768, maxWidth: 1920 });
  const isMobileOrTablet = useMediaQuery({ minWidth: 360, maxWidth: 768 });
  const isMobile = useMediaQuery({ maxWidth: 360 });

  return { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile };
}
```
훅은 이렇게 만들어져 있으며,

베이스 레이아웃에서 훅을 받아 아래와 같이 사용합니다.
```jsx
import { PropTypes } from 'prop-types';
import React from 'react';
import useResponsive from '../../hooks/useResponsive';

export default function BaseLayout({
  children,
  BigScreen,
  TabletOrDesktop,
  MobileOrTablet,
  Mobile,
}) {
  const { isBigScreen, isTabletOrDesktop, isMobileOrTablet, isMobile } = useResponsive();

  if (isBigScreen) return <BigScreen>{children}</BigScreen>;
  if (isTabletOrDesktop) return <TabletOrDesktop>{children}</TabletOrDesktop>;
  if (isMobileOrTablet) return <MobileOrTablet>{children}</MobileOrTablet>;
  if (isMobile) return <Mobile>{children}</Mobile>;
  return <>{children}</>;
}
```
저희가 해야 할 건 그저 베이스 레이아웃에다가 BigScreen, TabletOrDesktop, MobileOrTablet, Mobile에 해당하는 스타일드 컴포넌트 값을 집어넣는 것 뿐입니다!

```js
import React from 'react';
import styled from 'styled-components';
import { layoutPropTypes } from '../../utils/layoutPropTypes';
import BaseLayout from './Base.layout';

export default function HeaderLayout({ children }) {
  return (
    <BaseLayout
      BigScreen={StyledDesktopWrapper}
      TabletOrDesktop={StyledTabletToDesktopWrapper}
      MobileOrTablet={StyledMobileToTabletWrapper}
      Mobile={StyledMobileWrapper}
    >
      {children}
    </BaseLayout>
  );
}

const StyledDesktopWrapper = styled.div` .. `
...
```

- [x] 헤더에 적용하기
`Header.layout.jsx`를 만들고 각각 경우에 따른 스타일들을 적어줬습니다.
주로 자식 선택자들을 많이 써서 접근했습니다.

## 고민한 점, 질문거리

<!--+ 팀원들에게 할 말-->
* layout은 무조건 children을 prop으로 가지므로 layoutPropTypes를 util에다가 따로 빼뒀습니다. 임포트해서 사용하시면 편할 것입니다!
```js
import { layoutPropTypes } from '../../utils/layoutPropTypes';

...

___Layout.propTypes = layoutPropTypes;
```
* 다 width로 때리고 싶었으나, background-color을 건드리지 않기 위해 padding을 준 부분들이 있습니다
* 큰 화면이 작아지는 과정에서 변하는걸 기준으로 개발했기 때문에 스타일드 컴포넌트는 모두 이전 단계의 스타일드 컴포넌트를 상속받게 구현했습니다.
```js
const StyledWrapper = styled.div` ... `;

const StyledDesktopWrapper = styled(StyledWrapper)` ... `;

const StyledTabletToDesktopWrapper = styled(StyledDesktopWrapper)` ... `;

...
```

* 그러나 여러분은 마음 가는대로 하셔도 됩니다.
